### PR TITLE
fix(mpesa): set user to Administrator to bypass PermissionError durin…

### DIFF
--- a/frappe_mpsa_payments/frappe_mpsa_payments/api/m_pesa_api.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/api/m_pesa_api.py
@@ -322,6 +322,7 @@ def stk_push_callback(**kwargs) -> None:
     settings = frappe.get_doc(MPESA_SETTINGS_DOCTYPE, request_doc.settings)
 
     if status == "Completed" and request_doc.status != "Completed" and request_doc.reference_doctype == "Payment Request":
+        frappe.set_user("Administrator")
         payment_request = frappe.get_doc("Payment Request", request_doc.reference_name)
         try:
             payment_request.create_payment_entry()

--- a/frappe_mpsa_payments/frappe_mpsa_payments/api/mpesa_response_handler.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/api/mpesa_response_handler.py
@@ -26,6 +26,7 @@ def transaction_status_on_success(response: dict, document_name: str, **kwargs) 
 
         # Only proceed if the new status is "Completed" and it's a change from the current status
         if status == "Completed" and request_doc.status != "Completed" and request_doc.reference_doctype == "Payment Request":
+            frappe.set_user("Administrator")
             payment_request = frappe.get_doc("Payment Request", request_doc.reference_name)
             try:
                 payment_request.create_payment_entry()

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/mpesa_settings.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/mpesa_settings/mpesa_settings.py
@@ -128,8 +128,6 @@ class MpesaSettings(Document):
 
         for i, amount in enumerate(request_amounts):
             args.request_amount = amount
-            print(f"Processing request {i + 1} with amount: {amount}")
-            print(f"Reference Doctype: {args.reference_doctype}, Reference Docname: {args.reference_docname}")
             if frappe.flags.in_test:
                 from .test_mpesa_settings import get_payment_request_response_payload
 


### PR DESCRIPTION
…g payment entry creation

On successful M-Pesa STK callback, creating a Payment Entry from a Payment Request fails with:

    frappe.exceptions.PermissionError

This happens because internal ERPNext functions (like `get_account_details`) explicitly call `frappe.has_permission("Payment Entry", throw=True)` and do not respect `frappe.flags.ignore_permissions`.

To resolve this, we explicitly set the user to 'Administrator' before calling `create_payment_entry()` to ensure all downstream permission checks pass.

This pull request introduces changes to the `frappe_mpsa_payments` module to enhance functionality and improve code maintainability. The key updates include setting the user context to "Administrator" before creating payment entries and removing debug print statements from the `request_for_payment` method.

### Enhancements to payment processing:

* In both `stk_push_callback` (`frappe_mpsa_payments/api/m_pesa_api.py`) and `transaction_status_on_success` (`frappe_mpsa_payments/api/mpesa_response_handler.py`), the user context is explicitly set to "Administrator" before invoking `create_payment_entry`. This ensures the necessary permissions are in place for creating payment entries. [[1]](diffhunk://#diff-a86a14acba94754d356dbf7e906a64cdf7993fce5c4a83e8ba3de94ccac1d050R325) [[2]](diffhunk://#diff-c211cd27aeac3866d2e321889e4001a230a08a17463c7c80ebde1dacf5550c2cR29)

### Code cleanup:

* Removed debug print statements from the `request_for_payment` method in `mpesa_settings.py`. This improves code readability and prevents unnecessary console output during execution.